### PR TITLE
Warn when submodule attributes and submodule names conflict

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,4 +34,4 @@ jobs:
 
     - name: Test
       run: |
-        pytest
+        PYTHONPATH=. pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://gitlab.com/pycqa/flake8

--- a/tests/fake_func.py
+++ b/tests/fake_func.py
@@ -1,0 +1,2 @@
+def fake_func():
+    pass

--- a/tests/test_lazy_loader.py
+++ b/tests/test_lazy_loader.py
@@ -94,3 +94,11 @@ def test_lazy_attach():
     for k, v in expected.items():
         if v is not None:
             assert locls[k] == v
+
+
+def test_attr_same_as_module():
+    __getattr__, __lazy_dir__, __all__ = lazy.attach(
+        "tests", submod_attrs={"fake_func": ["fake_func"]}
+    )
+    with pytest.warns(lazy.DelayedImportWarning):
+        __getattr__("fake_func")


### PR DESCRIPTION
Otherwise, it can be hard to predict what will be returned on
attribute access (probably the submodule).

This is in response to https://github.com/huggingface/huggingface_hub/pull/874#discussion_r873727353 on https://github.com/huggingface/huggingface_hub/pull/874