### PR TITLE
lazy_import as a context manager

### DIFF
--- a/tests/fake_pkg/__init__.py
+++ b/tests/fake_pkg/__init__.py
@@ -1,5 +1,4 @@
-import lazy_loader as lazy
+from lazy_loader import lazy_import
 
-__getattr__, __lazy_dir__, __all__ = lazy.attach(
-    __name__, submod_attrs={"some_func": ["some_func"]}
-)
+with lazy_import():
+    from . import some_func  # noqa: F401

--- a/tests/test_lazy_loader.py
+++ b/tests/test_lazy_loader.py
@@ -4,27 +4,21 @@ import types
 import pytest
 
 import lazy_loader as lazy
+from lazy_loader import lazy_import
 
 
-def test_lazy_import_basics():
-    math = lazy.load("math")
-    anything_not_real = lazy.load("anything_not_real")
+def test_import_builtin():
+    with lazy_import():
+        import math
 
     # Now test that accessing attributes does what it should
     assert math.sin(math.pi) == pytest.approx(0, 1e-6)
-    # poor-mans pytest.raises for testing errors on attribute access
-    try:
-        anything_not_real.pi
-        assert False  # Should not get here
-    except ModuleNotFoundError:
-        pass
-    assert isinstance(anything_not_real, lazy.DelayedImportErrorModule)
-    # see if it changes for second access
-    try:
-        anything_not_real.pi
-        assert False  # Should not get here
-    except ModuleNotFoundError:
-        pass
+
+
+def test_import_error():
+    with pytest.raises(ModuleNotFoundError):
+        with lazy_import():
+            import anything_not_real  # noqa: F401
 
 
 def test_lazy_import_impact_on_sys_modules():

--- a/tests/test_lazy_loader.py
+++ b/tests/test_lazy_loader.py
@@ -21,18 +21,25 @@ def test_import_error():
             import anything_not_real  # noqa: F401
 
 
-def test_lazy_import_impact_on_sys_modules():
-    math = lazy.load("math")
-    anything_not_real = lazy.load("anything_not_real")
+def test_builtin_is_in_sys_modules():
+    with lazy_import():
+        import math
 
     assert isinstance(math, types.ModuleType)
     assert "math" in sys.modules
-    assert isinstance(anything_not_real, lazy.DelayedImportErrorModule)
-    assert "anything_not_real" not in sys.modules
 
+    math.pi  # trigger load of math
+
+    assert isinstance(math, types.ModuleType)
+    assert "math" in sys.modules
+
+
+def test_non_builtin_is_in_sys_modules():
     # only do this if numpy is installed
     pytest.importorskip("numpy")
-    np = lazy.load("numpy")
+    with lazy_import():
+        import numpy as np
+
     assert isinstance(np, types.ModuleType)
     assert "numpy" in sys.modules
 

--- a/tests/test_lazy_loader.py
+++ b/tests/test_lazy_loader.py
@@ -92,8 +92,8 @@ def test_attach_same_module_and_attr_name():
 
     # Grab attribute twice, to ensure that importing it does not
     # override function by module
-    assert isinstance(fake_pkg.some_func, types.FunctionType)
-    assert isinstance(fake_pkg.some_func, types.FunctionType)
+    assert isinstance(fake_pkg.some_func, types.ModuleType)
+    assert isinstance(fake_pkg.some_func, types.ModuleType)
 
     # Ensure imports from submodule still work
     from fake_pkg.some_func import some_func

--- a/tests/test_lazy_loader.py
+++ b/tests/test_lazy_loader.py
@@ -21,6 +21,15 @@ def test_import_error():
             import anything_not_real  # noqa: F401
 
 
+def test_import_nonbuiltins():
+    pytest.importorskip("numpy")
+
+    with lazy_import():
+        import numpy as np
+
+    assert np.sin(np.pi) == pytest.approx(0, 1e-6)
+
+
 def test_builtin_is_in_sys_modules():
     with lazy_import():
         import math
@@ -47,25 +56,6 @@ def test_non_builtin_is_in_sys_modules():
 
     assert isinstance(np, types.ModuleType)
     assert "numpy" in sys.modules
-
-
-def test_lazy_import_nonbuiltins():
-    sp = lazy.load("scipy")
-    np = lazy.load("numpy")
-    if isinstance(sp, lazy.DelayedImportErrorModule):
-        try:
-            sp.pi
-            assert False
-        except ModuleNotFoundError:
-            pass
-    elif isinstance(np, lazy.DelayedImportErrorModule):
-        try:
-            np.sin(np.pi)
-            assert False
-        except ModuleNotFoundError:
-            pass
-    else:
-        assert np.sin(sp.pi) == pytest.approx(0, 1e-6)
 
 
 def test_lazy_attach():


### PR DESCRIPTION
Hi!

I tried a different approach to solve this problem,
which defers a standard import statement inside a context manager.

Usage:

```python
from lazy_loader import lazy_import

with lazy_import():
    import math  # lazy

math.pi  # executes module
```

Advantages:
- possibly simpler to adopt and explain,
- it eagerly raises an `ImportError` if a module is not found,
- it works with static type checkers, providing type hints and completions.

I'm not sure if it is missing some functionality that the current version of `lazy_loader` has.

How it works:

It injects LazyFinder to sys.meta_path, which searches with the rest of sys.meta_path's Finders.
If it found one, it wraps the resulting ModuleSpec in importlib.util.LazyLoader, which defers loading until first access.

I hope you can check it out!