### PR TITLE
Fix extension substitution to work with `*.pyc` files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,23 +16,23 @@ repos:
       - id: check-toml
       - id: check-added-large-files
   - repo: https://github.com/psf/black
-    rev: 22.8.0
+    rev: 22.10.0
     hooks:
       - id: black
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 5.0.4
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
     hooks:
       - id: flake8
         pass_filenames: true
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.38.0
+    rev: v3.3.1
     hooks:
       - id: pyupgrade
-        args: [--py37-plus]
+        args: [--py38-plus]
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.7.1
     hooks:

--- a/lazy_loader/__init__.py
+++ b/lazy_loader/__init__.py
@@ -237,7 +237,7 @@ def attach_stub(package_name: str, filename: str):
         If a stub file is not found for `filename`, or if the stubfile is formmated
         incorrectly (e.g. if it contains an relative import from outside of the module)
     """
-    stubfile = filename if filename.endswith("i") else f"{filename}i"
+    stubfile = filename if filename.endswith("i") else f"{os.path.splitext(filename)[0]}.pyi"
 
     if not os.path.exists(stubfile):
         raise ValueError(f"Cannot load imports from non-existent stub {stubfile!r}")

--- a/lazy_loader/__init__.py
+++ b/lazy_loader/__init__.py
@@ -237,7 +237,9 @@ def attach_stub(package_name: str, filename: str):
         If a stub file is not found for `filename`, or if the stubfile is formmated
         incorrectly (e.g. if it contains an relative import from outside of the module)
     """
-    stubfile = filename if filename.endswith("i") else f"{os.path.splitext(filename)[0]}.pyi"
+    stubfile = (
+        filename if filename.endswith("i") else f"{os.path.splitext(filename)[0]}.pyi"
+    )
 
     if not os.path.exists(stubfile):
         raise ValueError(f"Cannot load imports from non-existent stub {stubfile!r}")


### PR DESCRIPTION
This PR is the first to solve a problem mentioned in #38. 

It is possible that call
```
__getattr__, __lazy_dir__, _ = lazy.attach_stub(__name__, __file__)
```
Will provide the file name with `.pyc` extension so the lazy loader tries to open `.pyci` file, which does not exist.  


