### PR TITLE
ENH: Add require argument to load() to accept version specifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,3 +134,10 @@ In this case, if `numpy` is installed, but the version is less than 1.24,
 the `np` module returned will raise an error on attribute access. Using
 this feature is not all-or-nothing: One module may rely on one version of
 numpy, while another module may not set any requirement.
+
+_Note that the requirement must use the package [distribution name][] instead
+of the module [import name][]. For example, the `pyyaml` distribution provides
+the `yaml` module for import._
+
+[distribution name]: https://packaging.python.org/en/latest/glossary/#term-Distribution-Package
+[import name]: https://packaging.python.org/en/latest/glossary/#term-Import-Package

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ linalg = lazy.load('scipy.linalg', error_on_import=True)
 #### Optional requirements
 
 One use for lazy loading is for loading optional dependencies, with
-errors only arising when optional functionality is accessed. If optional
+`ImportErrors` only arising when optional functionality is accessed. If optional
 functionality depends on a specific version, a version requirement can
 be set:
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,22 @@ discouraged._
 
 You can ask `lazy.load` to raise import errors as soon as it is called:
 
-```
+```python
 linalg = lazy.load('scipy.linalg', error_on_import=True)
 ```
+
+#### Optional requirements
+
+One use for lazy loading is for loading optional dependencies, with
+errors only arising when optional functionality is accessed. If optional
+functionality depends on a specific version, a version requirement can
+be set:
+
+```python
+np = lazy.load("numpy", require="numpy >=1.24")
+```
+
+In this case, if `numpy` is installed, but the version is less than 1.24,
+the `np` module returned will raise an error on attribute access. Using
+this feature is not all-or-nothing: One module may rely on one version of
+numpy, while another module may not set any requirement.

--- a/lazy_loader/__init__.py
+++ b/lazy_loader/__init__.py
@@ -160,6 +160,14 @@ def load(fullname, *, require=None, error_on_import=False):
 
           sp = lazy.load('scipy')  # import scipy as sp
 
+    require : str
+        A dependency requirement as defined in PEP-508.  For example::
+
+          "numpy >=1.24"
+
+        If defined, the proxy module will raise an error if the installed
+        version does not satisfy the requirement.
+
     error_on_import : bool
         Whether to postpone raising import errors until the module is accessed.
         If set to `True`, import errors are raised as soon as `load` is called.

--- a/lazy_loader/__init__.py
+++ b/lazy_loader/__init__.py
@@ -7,16 +7,10 @@ Makes it easy to load subpackages and functions on demand.
 import ast
 import importlib
 import importlib.util
-import inspect
 import os
 import sys
 import types
 import warnings
-
-try:
-    import importlib_metadata
-except ImportError:
-    import importlib.metadata as importlib_metadata
 
 __all__ = ["attach", "load", "attach_stub"]
 
@@ -200,8 +194,12 @@ def load(fullname, *, require=None, error_on_import=False):
     if not have_module:
         not_found_message = f"No module named '{fullname}'"
     elif require is not None:
-        # Old style lazy loading to avoid polluting sys.modules
         import packaging.requirements
+
+        try:
+            import importlib_metadata
+        except ImportError:
+            import importlib.metadata as importlib_metadata
 
         req = packaging.requirements.Requirement(require)
         try:
@@ -221,6 +219,8 @@ def load(fullname, *, require=None, error_on_import=False):
     if not have_module:
         if error_on_import:
             raise ModuleNotFoundError(not_found_message)
+        import inspect
+
         try:
             parent = inspect.stack()[1]
             frame_data = {

--- a/lazy_loader/__init__.py
+++ b/lazy_loader/__init__.py
@@ -266,10 +266,6 @@ def _check_requirement(require: str) -> bool:
     )
 
 
-def have_module(module_like: types.ModuleType) -> bool:
-    return not isinstance(module_like, DelayedImportErrorModule)
-
-
 class _StubVisitor(ast.NodeVisitor):
     """AST visitor to parse a stub file for submodules and submod_attrs."""
 

--- a/lazy_loader/tests/test_lazy_loader.py
+++ b/lazy_loader/tests/test_lazy_loader.py
@@ -7,13 +7,6 @@ import pytest
 
 import lazy_loader as lazy
 
-try:
-    import importlib_metadata  # noqa
-
-    have_importlib_metadata = True
-except ImportError:
-    have_importlib_metadata = False
-
 
 def test_lazy_import_basics():
     math = lazy.load("math")
@@ -160,7 +153,8 @@ def test_stub_loading_errors(tmp_path):
 
 
 def test_require_kwarg():
-    dot = "_" if have_importlib_metadata else "."
+    have_importlib_metadata = importlib.util.find_spec("importlib.metadata") is not None
+    dot = "." if have_importlib_metadata else "_"
     # Test with a module that definitely exists, behavior hinges on requirement
     with mock.patch(f"importlib{dot}metadata.version") as version:
         version.return_value = "1.0.0"

--- a/lazy_loader/tests/test_lazy_loader.py
+++ b/lazy_loader/tests/test_lazy_loader.py
@@ -172,11 +172,3 @@ def test_require_kwarg():
     # raise a ValueError
     with pytest.raises(ValueError):
         lazy.load("math", require="somepkg >= 1.0")
-
-
-def test_have_module():
-    math = lazy.load("math")
-    anything_not_real = lazy.load("anything_not_real")
-
-    assert lazy.have_module(math)
-    assert not lazy.have_module(anything_not_real)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 description = "Makes it easy to load subpackages and functions on demand."
 dependencies = [
   "packaging",
-  "importlib_metadata; python_version < '3.9'",
+  "importlib_metadata; python_version < '3.8'",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,10 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
 ]
 description = "Makes it easy to load subpackages and functions on demand."
+dependencies = [
+  "packaging",
+  "importlib_metadata; python_version < '3.9'",
+]
 
 [project.optional-dependencies]
 test = ["pytest >= 7.4", "pytest-cov >= 4.1"]


### PR DESCRIPTION
This PR adds an optional `require` keyword argument to `load()` that accepts `requirements.txt`-style version specifiers.

```python
np = lazy.load("numpy", require="numpy >=1.24")
```

The effect is to make the import fail if the dependency exists but the version is not satisfied.

Closes #13.

---- 

<details><summary>Original text</summary>

Found a little time tonight to take a first stab at implementing `lazy.load_requirement()`, a variant of `lazy.load()` that accepts a `requirements.txt`-style requirement specifier. This would allow one to write:

```Python
nibabel, have_nibabel = lazy.load_requirement('nibabel >= 4.2')
yaml, have_yaml = lazy.load_requirement('pyyaml >= 6.0', 'yaml')
stats, have_scipy = lazy.load_requirements('scipy >= 1.9', 'scipy.stats')
```

The two-argument form is for when module names do not match distribution names or you want to lazily import a submodule while constraining the base module version.

I'll get to tests when I can, but might as well see if this much complexity is within-scope. I doubt it can be done much simpler.

</details>