### PR TITLE
expose submodules of attribute imports by default

### DIFF
--- a/lazy_loader/__init__.py
+++ b/lazy_loader/__init__.py
@@ -60,8 +60,9 @@ def attach(package_name, submodules=None, submod_attrs=None):
     if submodules is None:
         submodules = set()
     else:
-        submodules = set(submodules) | submod_attrs.keys()
+        submodules = set(submodules)
 
+    submodules |= submod_attrs.keys()
     attr_to_modules = {
         attr: mod for mod, attrs in submod_attrs.items() for attr in attrs
     }

--- a/lazy_loader/__init__.py
+++ b/lazy_loader/__init__.py
@@ -60,18 +60,16 @@ def attach(package_name, submodules=None, submod_attrs=None):
     if submodules is None:
         submodules = set()
     else:
-        submodules = set(submodules)
+        submodules = set(submodules) | submod_attrs.keys()
 
     attr_to_modules = {
         attr: mod for mod, attrs in submod_attrs.items() for attr in attrs
     }
 
-    __all__ = list(sorted(submodules | attr_to_modules.keys()))
+    __all__ = list(sorted(attr_to_modules.keys() | submodules))
 
     def __getattr__(name):
-        if name in submodules:
-            return importlib.import_module(f"{package_name}.{name}")
-        elif name in attr_to_modules:
+        if name in attr_to_modules:
             submod_path = f"{package_name}.{attr_to_modules[name]}"
             submod = importlib.import_module(submod_path)
             attr = getattr(submod, name)
@@ -84,6 +82,8 @@ def attach(package_name, submodules=None, submod_attrs=None):
                 pkg.__dict__[name] = attr
 
             return attr
+        elif name in submodules:
+            return importlib.import_module(f"{package_name}.{name}")
         else:
             raise AttributeError(f"No {package_name} attribute {name}")
 

--- a/lazy_loader/tests/test_lazy_loader.py
+++ b/lazy_loader/tests/test_lazy_loader.py
@@ -115,7 +115,7 @@ def test_stub_loading(tmp_path):
     stub = tmp_path / "stub.pyi"
     stub.write_text(FAKE_STUB)
     _get, _dir, _all = lazy.attach_stub("my_module", str(stub))
-    expect = {"gaussian", "sobel", "scharr", "prewitt", "roberts", "rank"}
+    expect = {"gaussian", "sobel", "scharr", "prewitt", "roberts", "rank", "_gaussian", "edges"}
     assert set(_dir()) == set(_all) == expect
 
 


### PR DESCRIPTION
This addresses one of the points addressed in #32

With this change, it should also be possible to do away with the distinction between `submodules` and `attr_to_modules`, because all submodules could be specified as `attr_to_modules` with an empty list of attributes or a special value (e.g. `None`).