### PR TITLE
Warn and discourage lazy.load of subpackages

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,16 @@ internal imports.
 Use `lazy.load` to lazily import external libraries:
 
 ```python
-linalg = lazy.load('scipy.linalg')  # `linalg` will only be loaded when accessed
+sp = lazy.load('scipy')  # `sp` will only be loaded when accessed
+sp.linalg.norm(...)
 ```
 
-You can also ask `lazy.load` to raise import errors as soon as it is called:
+_Note that lazily importing *sub*packages,
+i.e. `load('scipy.linalg')` will cause the package containing the
+subpackage to be imported immediately; thus, this usage is
+discouraged._
+
+You can ask `lazy.load` to raise import errors as soon as it is called:
 
 ```
 linalg = lazy.load('scipy.linalg', error_on_import=True)

--- a/lazy_loader/__init__.py
+++ b/lazy_loader/__init__.py
@@ -146,13 +146,12 @@ def load(fullname, error_on_import=False):
 
     Warning
     -------
-
-    While lazily loading subpackages technically works, it causes the
+    While lazily loading *sub*packages technically works, it causes the
     package (that contains the subpackage) to be eagerly loaded even
     if the package is already lazily loaded.
     So, you probably shouldn't use subpackages with this `load` feature.
     Instead you should encourage the package maintainers to use the
-    lazy_loader `attach` feature to make their subpackages lazily load.
+    `lazy_loader.attach` to make their subpackages load lazily.
 
     Parameters
     ----------

--- a/lazy_loader/tests/test_lazy_loader.py
+++ b/lazy_loader/tests/test_lazy_loader.py
@@ -30,12 +30,12 @@ def test_lazy_import_basics():
 
 def test_lazy_import_subpackages():
     with pytest.warns(RuntimeWarning):
-        ctextpad = lazy.load("curses.textpad")
-    assert "curses" in sys.modules
-    assert type(sys.modules["curses"]) == type(pytest)
-    assert isinstance(ctextpad, importlib.util._LazyModule)
-    assert "curses.textpad" in sys.modules
-    assert sys.modules["curses.textpad"] == ctextpad
+        hp = lazy.load("html.parser")
+    assert "html" in sys.modules
+    assert type(sys.modules["html"]) == type(pytest)
+    assert isinstance(hp, importlib.util._LazyModule)
+    assert "html.parser" in sys.modules
+    assert sys.modules["html.parser"] == hp
 
 
 def test_lazy_import_impact_on_sys_modules():

--- a/lazy_loader/tests/test_lazy_loader.py
+++ b/lazy_loader/tests/test_lazy_loader.py
@@ -1,3 +1,4 @@
+import importlib
 import sys
 import types
 
@@ -25,6 +26,16 @@ def test_lazy_import_basics():
         assert False  # Should not get here
     except ModuleNotFoundError:
         pass
+
+
+def test_lazy_import_subpackages():
+    with pytest.warns(RuntimeWarning):
+        ctextpad = lazy.load("curses.textpad")
+    assert "curses" in sys.modules
+    assert type(sys.modules["curses"]) == type(pytest)
+    assert isinstance(ctextpad, importlib.util._LazyModule)
+    assert "curses.textpad" in sys.modules
+    assert sys.modules["curses.textpad"] == ctextpad
 
 
 def test_lazy_import_impact_on_sys_modules():


### PR DESCRIPTION
The `importlib.find_spec` tool automatically (and eagerly) imports packages when subpackages are asked to be found. The older `find_loader` did not do that, but it is deprecated and will be removed in python v3.12.  While it might be possible to make the `load` feature work using manually build `ModuleSpec`s, the payoff is unlikely to be worth the convoluted errors obtained when something goes awry.  It would/will be much more effective for people to encourage the package to `attach` the subpackages so they can be lazily loaded.

That said, packages can still be lazily `load`ed.  And even subpackages can be lazily `load`ed though this causes the package to be eagerly imported. So there might be some use for this `load` function. This potential benefit might be enough reason to keep the function in this library. But I can also see that removing the function altogether would be reasonable too.

With that in mind, this PR changes the function to raise a RuntimeWarning when the input is a subpackage (has "." in the name of the package). It also changes the doc_strings to discourage the use of `lazy.load(sub.package)`.  And it adds a test to check for the warning, and to verify that the return value of `load` with subpackage input continues to provide an eagerly imported package with a lazily loaded subpackage.

I think this is better than leaving `load` unchanged -- some of the docs even suggested using it for subpackages.

But, is this better than removing `load`? 
