### PR TITLE
Avoid exception when __frame_data["code_context"] is None

### DIFF
--- a/lazy_loader/__init__.py
+++ b/lazy_loader/__init__.py
@@ -112,7 +112,7 @@ class DelayedImportErrorModule(types.ModuleType):
                 f"No module named '{fd['spec']}'\n\n"
                 "This error is lazily reported, having originally occured in\n"
                 f'  File {fd["filename"]}, line {fd["lineno"]}, in {fd["function"]}\n\n'
-                f'----> {"".join(fd["code_context"]).strip()}'
+                f'----> {"".join(fd["code_context"] or "").strip()}'
             )
 
 


### PR DESCRIPTION
As part of `DelayedImportErrorModule`, an exception message is created for `ModuleNotFound`.  That message creation uses `__frame_data` including `code_context`.  But it raises a secondary TypeError exception if `fd["code_context'] is None`. 

This PR handles the case of no `code_context` by adding ` or ""` to get `fd["code_context"] or ""`
See networkx/networkx#7062

I wasn't able to make a test for this easily because I don't know how to create some code for a test with code_context showing up as None.  But this change is presumably harmless at worst and hopes to reduce confusion when a moduleNotFound error is raised for a `DelayedImportErrorModule`.