### PR TITLE
Drop Python 3.7 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,16 +9,7 @@ jobs:
       matrix:
         os: [ubuntu, macos, windows]
         python-version:
-          [
-            "3.7",
-            "3.8",
-            "3.9",
-            "3.10",
-            "3.11",
-            "3.12-dev",
-            "pypy-3.8",
-            "pypy-3.9",
-          ]
+          ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy-3.8", "pypy-3.9"]
 
     steps:
       - uses: actions/checkout@v4

--- a/lazy_loader/__init__.py
+++ b/lazy_loader/__init__.py
@@ -43,8 +43,6 @@ def attach(package_name, submodules=None, submod_attrs=None):
         {'foo': ['someattr']}
       )
 
-    This functionality requires Python 3.7 or higher.
-
     Parameters
     ----------
     package_name : str
@@ -269,12 +267,9 @@ def _check_requirement(require: str) -> bool:
         True if the installed version of the dependency matches
         the specified version, False otherwise.
     """
-    import packaging.requirements
+    import importlib.metadata as importlib_metadata
 
-    try:
-        import importlib.metadata as importlib_metadata
-    except ImportError:  # PY37
-        import importlib_metadata
+    import packaging.requirements
 
     req = packaging.requirements.Requirement(require)
     return req.specifier.contains(

--- a/lazy_loader/__init__.py
+++ b/lazy_loader/__init__.py
@@ -267,13 +267,13 @@ def _check_requirement(require: str) -> bool:
         True if the installed version of the dependency matches
         the specified version, False otherwise.
     """
-    import importlib.metadata as importlib_metadata
+    import importlib.metadata
 
     import packaging.requirements
 
     req = packaging.requirements.Requirement(require)
     return req.specifier.contains(
-        importlib_metadata.version(req.name),
+        importlib.metadata.version(req.name),
         prereleases=True,
     )
 

--- a/lazy_loader/tests/test_lazy_loader.py
+++ b/lazy_loader/tests/test_lazy_loader.py
@@ -160,10 +160,8 @@ def test_stub_loading_errors(tmp_path):
 
 
 def test_require_kwarg():
-    have_importlib_metadata = importlib.util.find_spec("importlib.metadata") is not None
-    dot = "." if have_importlib_metadata else "_"
     # Test with a module that definitely exists, behavior hinges on requirement
-    with mock.patch(f"importlib{dot}metadata.version") as version:
+    with mock.patch("importlib.metadata.version") as version:
         version.return_value = "1.0.0"
         math = lazy.load("math", require="somepkg >= 2.0")
         assert isinstance(math, lazy.DelayedImportErrorModule)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ attr = 'lazy_loader.__version__'
 
 [tool.ruff]
 line-length = 88
-target-version = "py38"
 select = [
     "C",
     "E",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "lazy_loader"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 authors = [{name = "Scientific Python Developers"}]
 readme = "README.md"
 license = {file = "LICENSE.md"}
@@ -13,7 +13,6 @@ classifiers = [
   "Development Status :: 4 - Beta",
   "License :: OSI Approved :: BSD License",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.7",
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
@@ -23,7 +22,6 @@ classifiers = [
 description = "Makes it easy to load subpackages and functions on demand."
 dependencies = [
   "packaging",
-  "importlib_metadata; python_version < '3.8'",
 ]
 
 [project.optional-dependencies]
@@ -44,7 +42,7 @@ attr = 'lazy_loader.__version__'
 
 [tool.ruff]
 line-length = 88
-target-version = "py37"
+target-version = "py38"
 select = [
     "C",
     "E",


### PR DESCRIPTION
Python 3.7 end of life was 2023-06-27.