### PR TITLE
rf: Use list.copy() instead of list()

### DIFF
--- a/lazy_loader/__init__.py
+++ b/lazy_loader/__init__.py
@@ -90,13 +90,13 @@ def attach(package_name, submodules=None, submod_attrs=None):
             raise AttributeError(f"No {package_name} attribute {name}")
 
     def __dir__():
-        return list(__all__)
+        return __all__.copy()
 
     if os.environ.get("EAGER_IMPORT", ""):
         for attr in set(attr_to_modules.keys()) | submodules:
             __getattr__(attr)
 
-    return __getattr__, __dir__, list(__all__)
+    return __getattr__, __dir__, __all__.copy()
 
 
 class DelayedImportErrorModule(types.ModuleType):


### PR DESCRIPTION
Very slight optimization, based on reviewing #135. `list()` will convert any iterable into a list, which incidentally performs a copy, while `list.copy()` is an explicit operation. This bypasses input detection logic, but I think more importantly makes the intent clearer. Static type checking can also distinguish these cases.

See also https://github.com/scientific-python/lazy-loader/pull/135#discussion_r1878211842.

I'm not committed to this change, so if this strikes others as less clear or pointless optimization, feel free to close.